### PR TITLE
Fix wrong variable name in eos plugin

### DIFF
--- a/dist/scatter.cjs.js
+++ b/dist/scatter.cjs.js
@@ -308,7 +308,7 @@ class EOS extends Plugin {
             if(!network.isValid()) throw Error.noNetwork();
             const httpEndpoint = `${network.protocol}://${network.hostport()}`;
 
-            const chainId = network.hasOwnProperty('chainId') && network.chainId.length ? network.chainId : options.chainId;
+            const chainId = network.hasOwnProperty('chainId') && network.chainId.length ? network.chainId : _options.chainId;
 
             // The proxy stands between the eosjs object and scatter.
             // This is used to add special functionality like adding `requiredFields` arrays to transactions
@@ -646,6 +646,22 @@ class Scatter {
                 whatfor,
                 isHash
             }
+        });
+    }
+
+    getPublicKey(blockchain){
+        throwNoAuth();
+        return SocketService.sendApiRequest({
+            type:'getPublicKey',
+            payload:{ blockchain }
+        });
+    }
+
+    linkAccount(publicKey, account, network){
+        throwNoAuth();
+        return SocketService.sendApiRequest({
+            type:'linkAccount',
+            payload:{ publicKey, account, network }
         });
     }
 

--- a/dist/scatter.esm.js
+++ b/dist/scatter.esm.js
@@ -304,7 +304,7 @@ class EOS extends Plugin {
             if(!network.isValid()) throw Error.noNetwork();
             const httpEndpoint = `${network.protocol}://${network.hostport()}`;
 
-            const chainId = network.hasOwnProperty('chainId') && network.chainId.length ? network.chainId : options.chainId;
+            const chainId = network.hasOwnProperty('chainId') && network.chainId.length ? network.chainId : _options.chainId;
 
             // The proxy stands between the eosjs object and scatter.
             // This is used to add special functionality like adding `requiredFields` arrays to transactions
@@ -642,6 +642,22 @@ class Scatter {
                 whatfor,
                 isHash
             }
+        });
+    }
+
+    getPublicKey(blockchain){
+        throwNoAuth();
+        return SocketService.sendApiRequest({
+            type:'getPublicKey',
+            payload:{ blockchain }
+        });
+    }
+
+    linkAccount(publicKey, account, network){
+        throwNoAuth();
+        return SocketService.sendApiRequest({
+            type:'linkAccount',
+            payload:{ publicKey, account, network }
         });
     }
 

--- a/src/plugins/defaults/eos.js
+++ b/src/plugins/defaults/eos.js
@@ -24,7 +24,7 @@ export default class EOS extends Plugin {
             if(!network.isValid()) throw Error.noNetwork();
             const httpEndpoint = `${network.protocol}://${network.hostport()}`;
 
-            const chainId = network.hasOwnProperty('chainId') && network.chainId.length ? network.chainId : options.chainId;
+            const chainId = network.hasOwnProperty('chainId') && network.chainId.length ? network.chainId : _options.chainId;
 
             // The proxy stands between the eosjs object and scatter.
             // This is used to add special functionality like adding `requiredFields` arrays to transactions


### PR DESCRIPTION
If you don't specify a `chainId`, it looks it up from the `options` variable which doesn't exist and throws an error which makes it unusable. I guess it was intended to read from `_options`.