### PR TITLE
Fix: plugin-eosjs2 broken in eosjs2 develop branch

### DIFF
--- a/packages/plugin-eosjs2/src/index.js
+++ b/packages/plugin-eosjs2/src/index.js
@@ -32,6 +32,7 @@ export default class ScatterEOS extends Plugin {
 
             sign:async (signargs) => {
                 const requiredFields = fieldsFetcher ? fieldsFetcher() : {};
+                const serializedTransactionBytes = signargs.serializedTransaction
                 signargs.serializedTransaction = Buffer.from(signargs.serializedTransaction).toString('hex');
 
                 return new Promise(async (resolve, reject) => {
@@ -39,7 +40,7 @@ export default class ScatterEOS extends Plugin {
                     SocketService.sendApiRequest({
                         type:'requestSignature',
                         payload
-                    }).then(x => resolve(x.signatures))
+                    }).then(x => resolve({ signatures: x.signatures, serializedTransaction: serializedTransactionBytes }))
                       .catch(x => reject(x))
                 })
             }


### PR DESCRIPTION
🚨  **Don't merge yet**

I was already using the upcoming unpublished version of eosjs2 (the `develop` branch), and there the plugin-eosjs2 is broken.

It's because of the change to `sign` which should now return an object with the `signature` and `serializedTransaction`, instead of just the `signature`.

[Here's the line](https://github.com/EOSIO/eosjs/blob/73152ade81fca0048cda609450d83f29ab7a76b0/src/eosjs-api-interfaces.ts#L66)

[Here's the diff](https://github.com/EOSIO/eosjs/compare/master...develop#diff-3aa92f3584066f7066491f493139248eL66)

I thought this might save you from researching this yourself in the future 