### PR TITLE
Call socket.close() instead of socket.disconnect()

### DIFF
--- a/packages/core/src/services/SocketService.js
+++ b/packages/core/src/services/SocketService.js
@@ -196,7 +196,7 @@ export default class SocketService {
     }
 
     static disconnect(){
-        if(socket) socket.disconnect();
+        if(socket) socket.close();
         return true;
     }
 


### PR DESCRIPTION
socket.disconnect() seems to throw and exceptions and it looks like socket.close() is what was intended here.