### PR TITLE
fix reconnect in extension

### DIFF
--- a/packages/core/src/wallets/Extension.js
+++ b/packages/core/src/wallets/Extension.js
@@ -33,7 +33,7 @@ export default class Extension extends Plugin {
 		return new Promise(async resolve => {
 			const found = await pollExistence();
 			if(found) {
-				if(!this.holderFns.get().wallet) this.holderFns.get().wallet = this.name;
+				if(this.holderFns && !this.holderFns.get().wallet) this.holderFns.get().wallet = this.name;
 				resolve(true);
 			}
 		})


### PR DESCRIPTION
When try to reconnect under extension (including some mobile wallet), there is no `holderFns` object any more.