### PR TITLE
I think here should pass chainId to create eos api

### DIFF
--- a/packages/plugin-eosjs2/src/index.js
+++ b/packages/plugin-eosjs2/src/index.js
@@ -68,7 +68,7 @@ export default class ScatterEOS extends Plugin {
 
             // The proxy stands between the eosjs object and scatter.
             // This is used to add special functionality like adding `requiredFields` arrays to transactions
-            return proxy(new _api(Object.assign(_options, {signatureProvider})), {
+            return proxy(new _api(Object.assign(_options, network, {signatureProvider})), {
                 get(eosInstance, method) {
 
                     return (...args) => {


### PR DESCRIPTION
I think here should pass chainId to create eos api param, If not, the eos api instance chainId will be undefined, then, it will call rpc get_info to get chainId, but rpc is undefined too.