### PR TITLE
Remove webpack-auto-inject-version + added bundle instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ From that point forward you can mix-match the plugins you require.
 | tronweb | `npm i -S @scatterjs/core @scatterjs/tron tronweb` |
 | web3 | `npm i -S @scatterjs/core @scatterjs/web3 web3` |
 
-
 ### CDN
 <!-- TODO: FIX CDN now that we are using an org scope -->
 ```
@@ -275,6 +274,24 @@ From that point forward you can mix-match the plugins you require.
 <script src="https://cdn.scattercdn.com/file/scatter-cdn/js/latest/scatterjs-plugin-lynx.min.js"></script>
 ```
 
+### Building the minified bundles from Git
+
+If you don't want to use Scatter's CDN, and you can't/don't want to use the NPM packages, then you can also
+build the Scatter-JS bundles from source. 
+
+Webpack will automatically add a version/license header to the top of the bundle files, so that you can identify 
+the version of each Scatter-JS component after you've copied them into a project.
+
+To generate the `.min.js` files from the source code in this repository, simply run the following commands:
+
+```bash
+git clone https://github.com/GetScatter/scatter-js.git
+cd scatter-js
+# Install NPM dependencies
+yarn install        # alternative: npm install
+# Generate the .min.js minified JS bundles into the folder 'bundles/' using Webpack
+yarn run pack       # alternative: npm run pack
+```
 
 
 <br/><br/>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const webpack = require('webpack')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
-const WebpackAutoInject = require('webpack-auto-inject-version');
 
 
 const getPackagePath = x => `./packages/${x}/src/index.js`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7195,11 +7195,6 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-auto-inject-version@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/webpack-auto-inject-version/-/webpack-auto-inject-version-1.2.2.tgz#8fa15f6ea7c4a2a4adcdc5d8b1dc47693dddc971"
-  integrity sha512-duFSWzZe/OY8zyr2DpymzZeY8yI1RSZ9hu9wDwZy/fhxwntgpEzTwyIB/U7ig+FB26mif8xx5zS1E3Co9c5cYA==
-
 webpack-cli@^3.3.9:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.9.tgz#79c27e71f94b7fe324d594ab64a8e396b9daa91a"


### PR DESCRIPTION
 - Removed `webpack-auto-inject-version` from webpack.config.js + yarn.lock (it's un-necessary)
 - Added the section **Building the minified bundles from Git** to the README, so users/developers know how to generate the `.min.js` bundle files themselves.