### PR TITLE
Add first batch of TypeScript declarations

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
 		"ws": "^6.1.0"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"types"
 	],
 	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
 	"publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
 	"name": "@scatterjs/core",
 	"version": "2.7.47",
 	"main": "dist/index.js",
+	"types": "types/index.d.ts",
 	"license": "MIT",
 	"dependencies": {
 		"create-hash": "^1.2.0",

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -1,0 +1,2 @@
+export { Plugin } from "./plugins/Plugin";
+export { PluginTypes } from "./plugins/PluginTypes";

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -1,6 +1,58 @@
-export { Blockchains } from "./models/Blockchains";
-export { Network } from "./models/Network";
-export { Token } from "./models/Token"; 
+import { Blockchains } from "./models/Blockchains";
+import { Network } from "./models/Network";
+import { Token } from "./models/Token"; 
 
-export { Plugin } from "./plugins/Plugin";
-export { PluginTypes } from "./plugins/PluginTypes";
+import { Plugin } from "./plugins/Plugin";
+import { PluginTypes } from "./plugins/PluginTypes";
+
+export const EVENTS: {
+    Disconnected: "dced";
+	LoggedOut: "logout";
+};
+
+interface ConnectProps {
+    network?: Network;
+    linkTimeout?: number;
+    allowHttp?: boolean;
+}
+
+class Scatter {
+    identity: any;
+    network: Network;
+    
+    loadPlugin(plugin: Plugin): void;
+    connect(pluginName: string, options?: ConnectProps): Promise<boolean>;
+}
+
+class Holder {
+    scatter: Scatter;
+
+    Plugin = Plugin;
+    PluginTypes: typeof PluginTypes;
+    Blockchains: typeof Blockchains;
+    Network = Network;
+    Token = Token;
+    SocketService = any;
+    EVENTS: typeof EVENTS;
+    WalletInterface = any;
+    WALLET_METHODS: any;
+
+    constructor(scatter: Scatter);
+
+    plugins(...plugins: Plugin[]): void;
+
+    connect(...params: Parameters<Index["connect"]>): ReturnType<Index["connect"]>;
+
+    catchAll(...params: any[]): void
+}
+
+export {
+    Plugin,
+    PluginTypes,
+    Blockchains,
+    Network,
+    EVENTS,
+};
+
+const holder: Holder;
+export default holder;

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Blockchains } from "./models/Blockchains";
+import { Blockchains, Blockchain } from "./models/Blockchains";
 import { Network } from "./models/Network";
 import { Token } from "./models/Token"; 
 
@@ -10,13 +10,113 @@ export const EVENTS: {
 	LoggedOut: "logout";
 };
 
+/**
+ * Optional fields that can be requested when asking for a RIDL Identity.
+ *
+ * @see https://get-scatter.com/docs/requirable-fields
+ */
+export interface RequireableFields {
+    accounts?: Network[];
+    personal?: Array<"firstname" | "lastname" | "email" | "birthdate">;
+    location?: Array<"phone" | "address" | "city" | "state" | "country" | "zipcode">;
+}
+
+/**
+ * Reputation and Identity Layer (RIDL), or Identity for short.
+ *
+ * @see https://ridl.get-scatter.com
+ */
+export interface Identity {
+    accounts: Account[];
+    hash: string;
+    publicKey: string;
+
+    /**
+     * RIDL Identity name.
+     *
+     * Not to be confused with account or personal name.
+     */
+    name: string;
+    personal?: {
+      firstname?: string;
+      lastname?: string;
+      email?: string;
+      birthdate?: string;
+    };
+    location?: {
+      phone?: string;
+      address?: string;
+      city?: string;
+      state?: string;
+      country?: string;
+      zipcode?: string;
+    }
+}
+
+export interface Account {
+    name: string;
+    publicKey: string;
+    blockchain: Blockchain;
+    isHardware: boolean;
+    authority: string;
+    chainId: string;
+}
+
 interface ConnectProps {
     network?: Network;
     linkTimeout?: number;
     allowHttp?: boolean;
 }
 
-class Scatter {
+/**
+ * The actual implementation has a `Holder` instance wrapped with a Proxy
+ * that will effectively expose the same methods of `Index` (for convenience
+ * renamed `Scatter` in these TypeScript declarations).
+ * 
+ * To not duplicate the same entries and to mimic that same end behavior, the
+ * shared methods will be part of this base class while `Holder` and `Scatter`
+ * will extend it.
+ */
+declare class ScatterBase {
+    disconnect(): boolean;
+    isConnected: () => boolean;
+    isPaired: () => boolean;
+    login: () => Promise<Identity>;
+    logout: () => Promise<boolean>;
+    getVersion: () => Promise<string>;
+    getIdentity: (requireableFields?: RequireableFields) => Promise<Identity>;
+    getAllAccountsFor: (requireableFields?: RequireableFields) => Promise<Identity>;
+    getIdentityFromPermissions: () => Promise<Identity>;
+    forgetIdentity: () => Promise<boolean>;
+    updateIdentity: (fields: { name: string, kyc?: any }) => Promise<boolean>;
+    authenticate: (nonce: any, data?: any, publicKey?: string) => Promise<any>;
+    getArbitrarySignature: (publicKey: string, data: string) => Promise<string>;
+    getPublicKey: (blockchain: Blockchain) => Promise<string>;
+    linkAccount: (account: any, network: any) => Promise<any>;
+    hasAccountFor: (network: Network) => Promise<boolean>;
+    suggestNetwork: (network: Network) => Promise<boolean>;
+    requestTransfer: (network: Network, to: string, amount: string, options?: {}) => Promise<any>;
+
+    /**
+     * Returns the RIDL Identity avatar image, if available.
+     *
+     * If available, the returned string will be a base64 encoded image asset.
+     */
+    getAvatar: () => Promise<string | undefined>;
+    requestSignature: (payload: any) => Promise<string>;
+    createTransaction: (
+      blockchain: Blockchain,
+      actions: any,
+      account: Account,
+      network: Network
+    ) => Promise<any>;
+    addToken: (token: Token, network: Network) => Promise<any>;
+}
+
+/**
+ * Originally called `Index` in implementation.
+ */
+declare class Scatter extends ScatterBase {
     identity: any;
     network: Network;
     
@@ -24,24 +124,24 @@ class Scatter {
     connect(pluginName: string, options?: ConnectProps): Promise<boolean>;
 }
 
-class Holder {
+declare class Holder extends ScatterBase {
     scatter: Scatter;
 
-    Plugin = Plugin;
+    Plugin: typeof Plugin;
     PluginTypes: typeof PluginTypes;
     Blockchains: typeof Blockchains;
-    Network = Network;
-    Token = Token;
-    SocketService = any;
+    Network: typeof Network;
+    Token: typeof Token;
+    SocketService: any;
     EVENTS: typeof EVENTS;
-    WalletInterface = any;
+    WalletInterface: any;
     WALLET_METHODS: any;
 
     constructor(scatter: Scatter);
 
     plugins(...plugins: Plugin[]): void;
 
-    connect(...params: Parameters<Index["connect"]>): ReturnType<Index["connect"]>;
+    connect(...params: Parameters<Scatter["connect"]>): ReturnType<Scatter["connect"]>;
 
     catchAll(...params: any[]): void
 }
@@ -51,8 +151,7 @@ export {
     PluginTypes,
     Blockchains,
     Network,
-    EVENTS,
 };
 
-const holder: Holder;
+declare const holder: Holder;
 export default holder;

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -1,2 +1,6 @@
+export { Blockchains } from "./models/Blockchains";
+export { Network } from "./models/Network";
+export { Token } from "./models/Token"; 
+
 export { Plugin } from "./plugins/Plugin";
 export { PluginTypes } from "./plugins/PluginTypes";

--- a/packages/core/types/models/Blockchains.d.ts
+++ b/packages/core/types/models/Blockchains.d.ts
@@ -1,0 +1,9 @@
+export type Blockchain = 'eos' | 'eth' | 'trx';
+
+export const Blockchains: {
+    EOS: 'eos';
+    ETH: 'eth';
+    TRX: 'trx';
+};
+
+export const BlockchainsArray: Array<{ key: string; value: string; }>;

--- a/packages/core/types/models/Network.d.ts
+++ b/packages/core/types/models/Network.d.ts
@@ -1,0 +1,32 @@
+import { Blockchain } from "./Blockchains";
+import { Token } from "./Token";
+
+type NetworkProtocol = "http" | "https";
+
+interface NetworkProps {
+    name?: string;
+    protocol: NetworkProtocol;
+    host: string;
+    port: number;
+    blockchain: Blockchain;
+    chainId: string;
+    token?: Token;
+}
+
+class Network implements NetworkProps {
+    name?: string;
+    protocol: NetworkProtocol;
+    host: string;
+    port: number;
+    blockchain: Blockchain;
+    chainId: string;
+    token?: Token;
+
+    constructor(name?: string, protocol?: NetworkProtocol, host?: string, port: number, blockchain?: Blockchain , chainId?: string);
+
+    static placeholder(): Network
+    static fromJson(json: NetworkProps): Network
+
+    fullhost(): string
+    unique(): string
+}

--- a/packages/core/types/models/Token.d.ts
+++ b/packages/core/types/models/Token.d.ts
@@ -1,0 +1,22 @@
+import { Blockchain } from "./Blockchains";
+
+interface TokenProps {
+    blockchain: Blockchain;
+    contract: string;
+    symbol: string;
+    name?: string;
+    decimals?: number;
+}
+
+export class Token implements TokenProps {
+    blockchain: Blockchain;
+    contract: string;
+    symbol: string;
+    name?: string;
+    decimals?: number;
+
+    constructor(blockchain?: Blockchain, contract?: string, symbol?: string, name?: string, decimals?: number);
+
+    static placeholder(): Token
+    static fromJson(json: TokenProps): Token
+}

--- a/packages/core/types/plugins/Plugin.d.ts
+++ b/packages/core/types/plugins/Plugin.d.ts
@@ -1,0 +1,12 @@
+import { PluginType } from "./PluginTypes";
+
+export class Plugin {
+    name: string;
+    type: PluginType;
+
+    static placeholder(): Plugin;
+    static fromJson(json: Object): Plugin;
+
+    isSignatureProvider(): boolean;
+    isValid(): boolean;
+}

--- a/packages/core/types/plugins/PluginTypes.d.ts
+++ b/packages/core/types/plugins/PluginTypes.d.ts
@@ -1,0 +1,6 @@
+export const PluginTypes: {
+    BLOCKCHAIN_SUPPORT: "blockchain_support";
+    WALLET_SUPPORT: "wallet_support";
+};
+
+export type PluginType = "blockchain_support" | "wallet_support";

--- a/packages/plugin-eosjs2/package.json
+++ b/packages/plugin-eosjs2/package.json
@@ -2,6 +2,7 @@
 	"name": "@scatterjs/eosjs2",
 	"version": "1.5.29",
 	"main": "dist/index.js",
+	"types": "types/index.d.ts",
 	"license": "MIT",
 	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
 	"publishConfig": {

--- a/packages/plugin-eosjs2/package.json
+++ b/packages/plugin-eosjs2/package.json
@@ -9,7 +9,8 @@
 		"access": "public"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"types"
 	],
 	"dependencies": {
 		"@scatterjs/core": "^2.7.47"

--- a/packages/plugin-eosjs2/types/index.d.ts
+++ b/packages/plugin-eosjs2/types/index.d.ts
@@ -1,0 +1,3 @@
+import { Plugin } from "@scatterjs/core";
+
+export default class ScatterEOS extends Plugin {}

--- a/packages/plugin-lynx/package.json
+++ b/packages/plugin-lynx/package.json
@@ -9,7 +9,8 @@
 		"access": "public"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"types"
 	],
 	"dependencies": {
 		"@scatterjs/core": "^2.7.47"

--- a/packages/plugin-lynx/package.json
+++ b/packages/plugin-lynx/package.json
@@ -2,6 +2,7 @@
 	"name": "@scatterjs/lynx",
 	"version": "1.6.40",
 	"main": "dist/index.js",
+	"types": "types/index.d.ts",
 	"license": "MIT",
 	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
 	"publishConfig": {

--- a/packages/plugin-lynx/types/index.d.ts
+++ b/packages/plugin-lynx/types/index.d.ts
@@ -1,0 +1,5 @@
+import { Plugin } from "@scatterjs/core";
+
+export default class ScatterLynx extends Plugin {
+    constructor(eosjs: { Api: any; JsonRpc: any });
+}


### PR DESCRIPTION
This PR adds the first chunk of TypeScript declarations to the existing code base as requested in #39.

Overall I believe these types are imperfect but still a good starting point. Over time we will iterate and improve them through usage and developer feedback.

### What is included
The focus is on most of the commonly used features of `@scatter-js/core`, such as:

- components used to initialize a Scatter dapp (creating a `Network` object, `connect` and `login` methods, etc)
- most of the [WALLET_METHODS](https://github.com/GetScatter/scatter-js/blob/master/packages/core/src/models/WalletInterface.js#L1)
- typings for `Identity`, `Account` and other objects returned from Scatter

In addition, typings for `@scatter-js/eosjs2` and `@scatter-js/lynx` plugins are added.

### What is not included
- Accuracy. The existing code base lacks comments and documentation, so finding out the right types is not trivial. Over time this will, however, improve through feedback from developers.
- Some less commonly used features are still missing types. For now, these are marked as `any`.
- Some parts rely on existing typings from the `eosjs` package, mainly the `Api` and `JsonRpc` classes. However, I did not take the liberty of adding this package as a peer dependency (maybe @nsjames can tell me if it is ok or not) so for now, those types are replaced with `any` as well.
