### PR TITLE
Link each npm module to github

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@scatterjs/core",
-    "version": "2.7.51",
-    "main": "dist/index.js",
-    "license": "MIT",
-    "repository": "github:GetScatter/scatter-js",
-    "dependencies": {
-        "create-hash": "^1.2.0",
-        "device-uuid": "^1.0.4",
-        "es6-promise": "^4.2.4",
-        "get-random-values": "^1.2.0",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^6.1.0"
-    },
-    "files": [
-        "dist"
-    ],
-    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-    "publishConfig": {
-        "access": "public"
-    }
+	"name": "@scatterjs/core",
+	"version": "2.7.51",
+	"main": "dist/index.js",
+	"license": "MIT",
+	"repository": "github:GetScatter/scatter-js",
+	"dependencies": {
+		"create-hash": "^1.2.0",
+		"device-uuid": "^1.0.4",
+		"es6-promise": "^4.2.4",
+		"get-random-values": "^1.2.0",
+		"isomorphic-ws": "^4.0.1",
+		"ws": "^6.1.0"
+	},
+	"files": [
+		"dist"
+	],
+	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,10 @@
 	"version": "2.7.51",
 	"main": "dist/index.js",
 	"license": "MIT",
-	"repository": "github:GetScatter/scatter-js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/GetScatter/scatter-js"
+	},
 	"dependencies": {
 		"create-hash": "^1.2.0",
 		"device-uuid": "^1.0.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "@scatterjs/core",
-  "version": "2.7.51",
-  "main": "dist/index.js",
-  "license": "MIT",
-  "repository": "github:GetScatter/scatter-js",
-  "dependencies": {
-    "create-hash": "^1.2.0",
-    "device-uuid": "^1.0.4",
-    "es6-promise": "^4.2.4",
-    "get-random-values": "^1.2.0",
-    "isomorphic-ws": "^4.0.1",
-    "ws": "^6.1.0"
-  },
-  "files": [
-    "dist"
-  ],
-  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@scatterjs/core",
+    "version": "2.7.51",
+    "main": "dist/index.js",
+    "license": "MIT",
+    "repository": "github:GetScatter/scatter-js",
+    "dependencies": {
+        "create-hash": "^1.2.0",
+        "device-uuid": "^1.0.4",
+        "es6-promise": "^4.2.4",
+        "get-random-values": "^1.2.0",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^6.1.0"
+    },
+    "files": [
+        "dist"
+    ],
+    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,21 +1,22 @@
 {
-	"name": "@scatterjs/core",
-	"version": "2.7.51",
-	"main": "dist/index.js",
-	"license": "MIT",
-	"dependencies": {
-		"create-hash": "^1.2.0",
-		"device-uuid": "^1.0.4",
-		"es6-promise": "^4.2.4",
-		"get-random-values": "^1.2.0",
-		"isomorphic-ws": "^4.0.1",
-		"ws": "^6.1.0"
-	},
-	"files": [
-		"dist"
-	],
-	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "@scatterjs/core",
+  "version": "2.7.51",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": "github:GetScatter/scatter-js",
+  "dependencies": {
+    "create-hash": "^1.2.0",
+    "device-uuid": "^1.0.4",
+    "es6-promise": "^4.2.4",
+    "get-random-values": "^1.2.0",
+    "isomorphic-ws": "^4.0.1",
+    "ws": "^6.1.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/plugin-eosjs/package.json
+++ b/packages/plugin-eosjs/package.json
@@ -3,7 +3,10 @@
 	"version": "1.5.34",
 	"main": "dist/index.js",
 	"license": "MIT",
-	"repository": "github:GetScatter/scatter-js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/GetScatter/scatter-js"
+	},
 	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
 	"publishConfig": {
 		"access": "public"

--- a/packages/plugin-eosjs/package.json
+++ b/packages/plugin-eosjs/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@scatterjs/eosjs",
-    "version": "1.5.34",
-    "main": "dist/index.js",
-    "license": "MIT",
-    "repository": "github:GetScatter/scatter-js",
-    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-    "publishConfig": {
-        "access": "public"
-    },
-    "files": [
-        "dist"
-    ],
-    "dependencies": {
-        "@scatterjs/core": "^2.7.51"
-    }
+	"name": "@scatterjs/eosjs",
+	"version": "1.5.34",
+	"main": "dist/index.js",
+	"license": "MIT",
+	"repository": "github:GetScatter/scatter-js",
+	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist"
+	],
+	"dependencies": {
+		"@scatterjs/core": "^2.7.51"
+	}
 }

--- a/packages/plugin-eosjs/package.json
+++ b/packages/plugin-eosjs/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@scatterjs/eosjs",
-  "version": "1.5.34",
-  "main": "dist/index.js",
-  "license": "MIT",
-  "repository": "github:GetScatter/scatter-js",
-  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "dist"
-  ],
-  "dependencies": {
-    "@scatterjs/core": "^2.7.51"
-  }
+    "name": "@scatterjs/eosjs",
+    "version": "1.5.34",
+    "main": "dist/index.js",
+    "license": "MIT",
+    "repository": "github:GetScatter/scatter-js",
+    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "@scatterjs/core": "^2.7.51"
+    }
 }

--- a/packages/plugin-eosjs/package.json
+++ b/packages/plugin-eosjs/package.json
@@ -1,16 +1,17 @@
 {
-	"name": "@scatterjs/eosjs",
-	"version": "1.5.34",
-	"main": "dist/index.js",
-	"license": "MIT",
-	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-	"publishConfig": {
-		"access": "public"
-	},
-	"files": [
-		"dist"
-	],
-	"dependencies": {
-		"@scatterjs/core": "^2.7.51"
-	}
+  "name": "@scatterjs/eosjs",
+  "version": "1.5.34",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": "github:GetScatter/scatter-js",
+  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@scatterjs/core": "^2.7.51"
+  }
 }

--- a/packages/plugin-eosjs2/package.json
+++ b/packages/plugin-eosjs2/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@scatterjs/eosjs2",
-    "version": "1.5.33",
-    "main": "dist/index.js",
-    "license": "MIT",
-    "repository": "github:GetScatter/scatter-js",
-    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-    "publishConfig": {
-        "access": "public"
-    },
-    "files": [
-        "dist"
-    ],
-    "dependencies": {
-        "@scatterjs/core": "^2.7.51"
-    }
+	"name": "@scatterjs/eosjs2",
+	"version": "1.5.33",
+	"main": "dist/index.js",
+	"license": "MIT",
+	"repository": "github:GetScatter/scatter-js",
+	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist"
+	],
+	"dependencies": {
+		"@scatterjs/core": "^2.7.51"
+	}
 }

--- a/packages/plugin-eosjs2/package.json
+++ b/packages/plugin-eosjs2/package.json
@@ -3,7 +3,10 @@
 	"version": "1.5.33",
 	"main": "dist/index.js",
 	"license": "MIT",
-	"repository": "github:GetScatter/scatter-js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/GetScatter/scatter-js"
+	},
 	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
 	"publishConfig": {
 		"access": "public"

--- a/packages/plugin-eosjs2/package.json
+++ b/packages/plugin-eosjs2/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@scatterjs/eosjs2",
-  "version": "1.5.33",
-  "main": "dist/index.js",
-  "license": "MIT",
-  "repository": "github:GetScatter/scatter-js",
-  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "dist"
-  ],
-  "dependencies": {
-    "@scatterjs/core": "^2.7.51"
-  }
+    "name": "@scatterjs/eosjs2",
+    "version": "1.5.33",
+    "main": "dist/index.js",
+    "license": "MIT",
+    "repository": "github:GetScatter/scatter-js",
+    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "@scatterjs/core": "^2.7.51"
+    }
 }

--- a/packages/plugin-eosjs2/package.json
+++ b/packages/plugin-eosjs2/package.json
@@ -1,16 +1,17 @@
 {
-	"name": "@scatterjs/eosjs2",
-	"version": "1.5.33",
-	"main": "dist/index.js",
-	"license": "MIT",
-	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-	"publishConfig": {
-		"access": "public"
-	},
-	"files": [
-		"dist"
-	],
-	"dependencies": {
-		"@scatterjs/core": "^2.7.51"
-	}
+  "name": "@scatterjs/eosjs2",
+  "version": "1.5.33",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": "github:GetScatter/scatter-js",
+  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@scatterjs/core": "^2.7.51"
+  }
 }

--- a/packages/plugin-lynx/package.json
+++ b/packages/plugin-lynx/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@scatterjs/lynx",
-  "version": "1.6.44",
-  "main": "dist/index.js",
-  "license": "MIT",
-  "repository": "github:GetScatter/scatter-js",
-  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "dist"
-  ],
-  "dependencies": {
-    "@scatterjs/core": "^2.7.51"
-  }
+    "name": "@scatterjs/lynx",
+    "version": "1.6.44",
+    "main": "dist/index.js",
+    "license": "MIT",
+    "repository": "github:GetScatter/scatter-js",
+    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "@scatterjs/core": "^2.7.51"
+    }
 }

--- a/packages/plugin-lynx/package.json
+++ b/packages/plugin-lynx/package.json
@@ -1,16 +1,17 @@
 {
-	"name": "@scatterjs/lynx",
-	"version": "1.6.44",
-	"main": "dist/index.js",
-	"license": "MIT",
-	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-	"publishConfig": {
-		"access": "public"
-	},
-	"files": [
-		"dist"
-	],
-	"dependencies": {
-		"@scatterjs/core": "^2.7.51"
-	}
+  "name": "@scatterjs/lynx",
+  "version": "1.6.44",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": "github:GetScatter/scatter-js",
+  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@scatterjs/core": "^2.7.51"
+  }
 }

--- a/packages/plugin-lynx/package.json
+++ b/packages/plugin-lynx/package.json
@@ -3,7 +3,10 @@
 	"version": "1.6.44",
 	"main": "dist/index.js",
 	"license": "MIT",
-	"repository": "github:GetScatter/scatter-js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/GetScatter/scatter-js"
+	},
 	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
 	"publishConfig": {
 		"access": "public"

--- a/packages/plugin-lynx/package.json
+++ b/packages/plugin-lynx/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@scatterjs/lynx",
-    "version": "1.6.44",
-    "main": "dist/index.js",
-    "license": "MIT",
-    "repository": "github:GetScatter/scatter-js",
-    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-    "publishConfig": {
-        "access": "public"
-    },
-    "files": [
-        "dist"
-    ],
-    "dependencies": {
-        "@scatterjs/core": "^2.7.51"
-    }
+	"name": "@scatterjs/lynx",
+	"version": "1.6.44",
+	"main": "dist/index.js",
+	"license": "MIT",
+	"repository": "github:GetScatter/scatter-js",
+	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist"
+	],
+	"dependencies": {
+		"@scatterjs/core": "^2.7.51"
+	}
 }

--- a/packages/plugin-tron/package.json
+++ b/packages/plugin-tron/package.json
@@ -3,7 +3,10 @@
 	"version": "1.3.33",
 	"main": "dist/index.js",
 	"license": "MIT",
-	"repository": "github:GetScatter/scatter-js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/GetScatter/scatter-js"
+	},
 	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
 	"publishConfig": {
 		"access": "public"

--- a/packages/plugin-tron/package.json
+++ b/packages/plugin-tron/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@scatterjs/tron",
-  "version": "1.3.33",
-  "main": "dist/index.js",
-  "license": "MIT",
-  "repository": "github:GetScatter/scatter-js",
-  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "dist"
-  ],
-  "dependencies": {
-    "@scatterjs/core": "^2.7.51"
-  }
+    "name": "@scatterjs/tron",
+    "version": "1.3.33",
+    "main": "dist/index.js",
+    "license": "MIT",
+    "repository": "github:GetScatter/scatter-js",
+    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "@scatterjs/core": "^2.7.51"
+    }
 }

--- a/packages/plugin-tron/package.json
+++ b/packages/plugin-tron/package.json
@@ -1,16 +1,17 @@
 {
-	"name": "@scatterjs/tron",
-	"version": "1.3.33",
-	"main": "dist/index.js",
-	"license": "MIT",
-	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-	"publishConfig": {
-		"access": "public"
-	},
-	"files": [
-		"dist"
-	],
-	"dependencies": {
-		"@scatterjs/core": "^2.7.51"
-	}
+  "name": "@scatterjs/tron",
+  "version": "1.3.33",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": "github:GetScatter/scatter-js",
+  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@scatterjs/core": "^2.7.51"
+  }
 }

--- a/packages/plugin-tron/package.json
+++ b/packages/plugin-tron/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@scatterjs/tron",
-    "version": "1.3.33",
-    "main": "dist/index.js",
-    "license": "MIT",
-    "repository": "github:GetScatter/scatter-js",
-    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-    "publishConfig": {
-        "access": "public"
-    },
-    "files": [
-        "dist"
-    ],
-    "dependencies": {
-        "@scatterjs/core": "^2.7.51"
-    }
+	"name": "@scatterjs/tron",
+	"version": "1.3.33",
+	"main": "dist/index.js",
+	"license": "MIT",
+	"repository": "github:GetScatter/scatter-js",
+	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist"
+	],
+	"dependencies": {
+		"@scatterjs/core": "^2.7.51"
+	}
 }

--- a/packages/plugin-web3/package.json
+++ b/packages/plugin-web3/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "@scatterjs/web3",
-    "version": "1.5.37",
-    "main": "dist/index.js",
-    "license": "MIT",
-    "repository": "github:GetScatter/scatter-js",
-    "dependencies": {
-        "@scatterjs/core": "^2.7.51",
-        "web3-provider-engine": "^14.1.0"
-    },
-    "files": [
-        "dist"
-    ],
-    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-    "publishConfig": {
-        "access": "public"
-    }
+	"name": "@scatterjs/web3",
+	"version": "1.5.37",
+	"main": "dist/index.js",
+	"license": "MIT",
+	"repository": "github:GetScatter/scatter-js",
+	"dependencies": {
+		"@scatterjs/core": "^2.7.51",
+		"web3-provider-engine": "^14.1.0"
+	},
+	"files": [
+		"dist"
+	],
+	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/plugin-web3/package.json
+++ b/packages/plugin-web3/package.json
@@ -1,17 +1,18 @@
 {
-	"name": "@scatterjs/web3",
-	"version": "1.5.37",
-	"main": "dist/index.js",
-	"license": "MIT",
-	"dependencies": {
-		"@scatterjs/core": "^2.7.51",
-		"web3-provider-engine": "^14.1.0"
-	},
-	"files": [
-		"dist"
-	],
-	"gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "@scatterjs/web3",
+  "version": "1.5.37",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": "github:GetScatter/scatter-js",
+  "dependencies": {
+    "@scatterjs/core": "^2.7.51",
+    "web3-provider-engine": "^14.1.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/plugin-web3/package.json
+++ b/packages/plugin-web3/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@scatterjs/web3",
-  "version": "1.5.37",
-  "main": "dist/index.js",
-  "license": "MIT",
-  "repository": "github:GetScatter/scatter-js",
-  "dependencies": {
-    "@scatterjs/core": "^2.7.51",
-    "web3-provider-engine": "^14.1.0"
-  },
-  "files": [
-    "dist"
-  ],
-  "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@scatterjs/web3",
+    "version": "1.5.37",
+    "main": "dist/index.js",
+    "license": "MIT",
+    "repository": "github:GetScatter/scatter-js",
+    "dependencies": {
+        "@scatterjs/core": "^2.7.51",
+        "web3-provider-engine": "^14.1.0"
+    },
+    "files": [
+        "dist"
+    ],
+    "gitHead": "dadb46787c05b190765b3a112b85d9d26c451c08",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/plugin-web3/package.json
+++ b/packages/plugin-web3/package.json
@@ -3,7 +3,10 @@
 	"version": "1.5.37",
 	"main": "dist/index.js",
 	"license": "MIT",
-	"repository": "github:GetScatter/scatter-js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/GetScatter/scatter-js"
+	},
 	"dependencies": {
 		"@scatterjs/core": "^2.7.51",
 		"web3-provider-engine": "^14.1.0"


### PR DESCRIPTION
This would allow npmjs to properly link users to this github page. This will help with discoverability, gaining users, and gaining trust 🙌

Here's an example of the link that https://www.npmjs.com/package/@scatterjs/core will have in the right-hand nav after merging this:

![image](https://user-images.githubusercontent.com/3408480/76251368-4508ce00-621d-11ea-98d1-8a6d79098ee1.png) See it in action here: https://www.npmjs.com/package/eosjs

Meanwhile currently, there's no way to find the github repo for this from npm. This affects discoverability in searching, SEO, and developer trust (since they can't easily find the source-code on github):



